### PR TITLE
cli: allow specifying custom Wormhole code length

### DIFF
--- a/src/fowl/cli.py
+++ b/src/fowl/cli.py
@@ -46,11 +46,17 @@ def fow(ctx, ip_privacy, mailbox):
 
 @fow.command()
 @click.pass_context
-def invite(ctx):
+@click.option(
+    "--code-length",
+    default=2,
+    help="Length of the Wormhole code",
+)
+def invite(ctx, code_length):
     """
     Start a new forwarding session, allocating a code that can be used
     on another computer to join a forwarding session
     """
+    ctx.obj = evolve(ctx.obj, code_length=code_length)
     def run(reactor):
         return ensureDeferred(
             forward(


### PR DESCRIPTION
It might be nice to use the `_Config` default for the CLI default automatically, but I have never used `attrs` and frozen classes before so I do not know what the best way to do that would be (is it possible without instantiating the class?) and so I followed the example of `--clearnet` and set the CLI default to the same value manually.
