### PR TITLE
[RFC] cli: specify endpoints in a SSH-like way

### DIFF
--- a/src/fowl/_proto.py
+++ b/src/fowl/_proto.py
@@ -54,6 +54,7 @@ class _Config:
     debug_state: bool = False
     stdout: IO = sys.stdout
     create_stdio: Callable = None  # returns a StandardIO work-alike, for testing
+    initial_commands: dict = {}
 
 
 async def wormhole_from_config(config, wormhole_create=None):
@@ -878,6 +879,18 @@ async def _forward_loop(config, w):
     verifier_bytes = await w.get_verifier()  # might WrongPasswordError
 
     listening_ports = []
+
+    for remote in config.initial_commands["remote"]:
+        await _remote_to_local_forward(control_proto, listening_ports.append, {
+            "remote-endpoint": ':'.join(remote.split(':')[:2]),
+            "local-endpoint": ':'.join(remote.split(':')[2:]),
+            })
+
+    for local in config.initial_commands["local"]:
+        await _local_to_remote_forward(reactor, config, connect_ep, listening_ports.append, {
+            "listen-endpoint": ':'.join(local.split(':')[:2]),
+            "local-endpoint": ':'.join(local.split(':')[2:]),
+            })
 
     # arrange to read incoming commands from stdin
     create_stdio = config.create_stdio or StandardIO

--- a/src/fowl/cli.py
+++ b/src/fowl/cli.py
@@ -29,9 +29,17 @@ from ._proto import (
     default=PUBLIC_MAILBOX_URL,
     help="URL for the mailbox server to use",
 )
+@click.option(
+    "-L",
+    multiple=True,
+)
+@click.option(
+    "-R",
+    multiple=True,
+)
 @click.group()
 @click.pass_context
-def fowl(ctx, ip_privacy, mailbox):
+def fowl(ctx, ip_privacy, mailbox, l, r):
     """
     Forward Over Wormhole
 
@@ -41,6 +49,10 @@ def fowl(ctx, ip_privacy, mailbox):
     ctx.obj = _Config(
         relay_url=mailbox,
         use_tor=bool(ip_privacy),
+        initial_commands = {
+            'local': l,
+            'remote': r,
+            }
     )
 
 


### PR DESCRIPTION
This is a rather proof of concept implementation of a simple command line interface based on SSH. It allows the invoker to specify binding commands on the command line and these then get executed right after the connection is established. It is still possible to specify more bindings via JSON commands afterwards.

One weak spot might be that it assumes the format of the arguments to be `proto:port:proto:address:port`, while I believe that the JSON way allows for more formats. This was done to preserve the similarity to SSH, however it will probably make more sense to twist the format away from it, for instance by separating the endpoints by some other character than colon or by splitting these into two CLI flags in parallel with what the JSON interface does. Once this is resolved, it would be nice not to forget to add `help` and format hints to the CLI options.
