### PR TITLE
remove invite and accept subcommands

### DIFF
--- a/integration/test_happy.py
+++ b/integration/test_happy.py
@@ -74,9 +74,9 @@ class _FowlProtocol(ProcessProtocol):
         ]
 
 
-async def fowl(reactor, request, subcommand, *extra_args, mailbox=None, startup=True):
+async def fowl(reactor, request, *extra_args, mailbox=None, startup=True):
     """
-    Run `fowl` with a given subcommand
+    Run `fowl`
     """
 
     args = [
@@ -88,7 +88,6 @@ async def fowl(reactor, request, subcommand, *extra_args, mailbox=None, startup=
         args.extend([
             "--mailbox", mailbox,
         ])
-    args.append(subcommand)
     args.extend(extra_args)
     proto = _FowlProtocol()
     transport = await run_service(
@@ -158,13 +157,13 @@ async def test_happy_remote(reactor, request, wormhole):
     A session forwarding a single connection using the
     ``kind="remote"`` command.
     """
-    f0 = await fowl(reactor, request, "invite", mailbox=wormhole.url, startup=False)
+    f0 = await fowl(reactor, request, mailbox=wormhole.url, startup=False)
     code_msg = await f0.protocol.next_message(kind="wormhole-code")
 
     # normally the "code" is shared via human interaction
 
     f1 = await fowl(
-        reactor, request, "accept", code_msg["code"],
+        reactor, request, code_msg["code"],
         mailbox=wormhole.url, startup=False,
     )
     # open a listener of some sort
@@ -207,13 +206,13 @@ async def test_happy_local(reactor, request, wormhole):
     A session forwarding a single connection using the
     ``kind="local"`` command.
     """
-    f0 = await fowl(reactor, request, "invite", mailbox=wormhole.url, startup=False)
+    f0 = await fowl(reactor, request, mailbox=wormhole.url, startup=False)
     code_msg = await f0.protocol.next_message(kind="wormhole-code")
 
     # normally the "code" is shared via human interaction
 
     f1 = await fowl(
-        reactor, request, "accept", code_msg["code"],
+        reactor, request, code_msg["code"],
         mailbox=wormhole.url, startup=False,
     )
     # open a listener of some sort

--- a/src/fowl/_proto.py
+++ b/src/fowl/_proto.py
@@ -850,8 +850,8 @@ async def _forward_loop(config, w):
         w.allocate_code(config.code_length)
 
     code = await w.get_code()
-    # it's kind of weird to see this on "fow accept" so only show it
-    # if we actually allocated a code
+    # it's kind of weird to see this after supplying the code earlier so only
+    # show it if we have not done that
     if not config.code:
         print(
             json.dumps({

--- a/src/fowl/test/test_forward.py
+++ b/src/fowl/test/test_forward.py
@@ -17,8 +17,6 @@ from twisted.internet.endpoints import serverFromString, clientFromString
 
 
 from fowl.cli import fowl
-#from fow.cli import accept
-from fowl.cli import invite
 from fowl._proto import (
     _Config,
     wormhole_from_config,

--- a/testcase.py
+++ b/testcase.py
@@ -77,7 +77,7 @@ async def main(reactor):
     reactor.spawnProcess(
         host_proto,
         sys.executable,
-        [sys.executable, "-m", "fowl", "--mailbox", "ws://localhost:4000/v1", "invite"],
+        [sys.executable, "-m", "fowl", "--mailbox", "ws://localhost:4000/v1"],
         env={"PYTHONUNBUFFERED": "1"},
     )
     msg = await host_proto.next_message("wormhole-code")
@@ -87,7 +87,7 @@ async def main(reactor):
     reactor.spawnProcess(
         host_proto,
         sys.executable,
-        [sys.executable, "-m", "fowl", "--mailbox", "ws://localhost:4000/v1", "accept", msg["code"]],
+        [sys.executable, "-m", "fowl", "--mailbox", "ws://localhost:4000/v1", msg["code"]],
         env={"PYTHONUNBUFFERED": "1"},
     )
     print("connected")


### PR DESCRIPTION
While the distinction is somewhat intuitive, the underlying code is the
same and thus it only leads to code duplication.

Marked as draft as I have not tested the changes to the tests (nor updated the
documentation).

I believe this resolves our conversation on my very first PR.
