### PR TITLE
doc

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -177,6 +177,7 @@ It's not pretty, but it works fine.
 
 However, we want to talk to other machines.
 This means we need:
+
 * encryption;
 * and a way to arrange network connectivity
 


### PR DESCRIPTION
- **typo**
- **fix: broken bold**
- **missing newline for bull points**


Also in `fowl --help` the newline for the arguments seem to have been forgotten.