### PR TITLE
Remove readme rendering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
     "gpg",  # should use isis lovecruft's version?
     "pip-tools",
     "hatch",
+    "readme-renderer",
     "cuvner",
  ]
 


### PR DESCRIPTION
Remove rendering of README.rst in the CLI

This fixes two issues at once, only by deleting stuff.

It is a rather lazy fix for the two issues I encountered - I don't have enough experience with Python packaging etc. to keep the functionality, and also I think networking software does not need to ship its full documentation within its code.

Fixes #78
Fixes #79